### PR TITLE
chore: migrating by side-by-side deployment

### DIFF
--- a/08.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/99.MTLS-ambassador-migration/docs.md
+++ b/08.Server-integration/04.Mender-Gateway/10.Mutual-TLS-authentication/99.MTLS-ambassador-migration/docs.md
@@ -5,64 +5,29 @@ taxonomy:
 ---
 
 This guide will take you through the process of migrating from the deprecated `mtls-ambassador` to Mender Gateway.
-Mender Gateway uses a json configuration which by default is located at `/etc/mender/mender-gateway.conf`.
-The following snippet shows how to generate a configuration file compatible with Mender Gateway from the corresponding configuration environment variables exposed by the `mtls-ambassador`.
-```bash
-cat > mender-gateway.conf <<EOF
-{
-  "Features": {
-    "mTLS": {
-      "Enabled": true,
-      "MenderUsername": "${MTLS_MENDER_USER}",
-      "MenderPassword": "${MTLS_MENDER_PASS}",
-      "CACertificate": "${MTLS_MENDER_CERT}",
-      "BlacklistPath": "${MTLS_BLACKLIST_PATH}"
-    }
-  },
-  "HTTPS": {
-    "Enabled": true,
-    "Listen": "${MTLS_LISTEN:-8080}",
-    "MinimumTLSVersion": "${MTLS_HTTPS_TLS_VERSION_MIN:-1.2}",
-    "ServerCertificate": "${MTLS_SERVER_CERT:-/etc/mtls/certs/server/server.crt}",
-    "ServerKey": "${MTLS_SERVER_KEY:-/etc/mtls/certs/server/server.key}"
-  },
-  "UpstreamServer": {
-    "URL": "${MTLS_MENDER_BACKEND}",
-    "ServerCertificate": "${MTLS_MENDER_CERT}",
-    "InsecureSkipVerify": ${MTLS_InsecureSkipVerify:-false}
-  }
-}
-EOF
-```
+Mender Gateway is a drop-in replacement of the `mtls-ambassador`.
 
-<!--AUTOVERSION: "mender-gateway:%"/mender-gateway -->
-In your container deployment, replace the image reference with `registry.mender.io/mendersoftware/mender-gateway:1.3.0` and make sure the generated config file is mounted at `/etc/mender/mender-gateway.conf`.
-For example, for a kubernetes deployment you can apply the following patches to your manifests:
-```bash
-DEPLOYMENT_NAME="mender-mtls"
-CONTAINER_NAME="mender-mtls"
-kubectl create configmap mender-mtls-conf --from-file=mender-gateway.conf
+## Prerequisites
+1. You have a running `mtls-ambassador` deployment.
+2. You have the required key and certificate files for the `mtls-ambassador`.
+3. You have a DNS name pointing to the `mtls-ambassador` service.
 
-cat | kubectl patch deployment.apps "$DEPLOYMENT_NAME" -f- <<EOF
-{
-    "spec": {
-        "containers": [{
-            "name": "${CONTAINER_NAME}",
-            "image": "registry.mender.io/mendersoftware/mender-gateway:1.3.0",
-            "volumeMounts": [{
-                "mountPath": "/etc/mender/mender-gateway.conf",
-                "name": "mender-gateway-conf",
-                "subPath": "mender-gateway.conf",
-                "readOnly": true
-            }]
-        }],
-        "volumes": [{
-            "configMap": {
-                "name": "mender-gateway-conf"
-            },
-            "name": "mender-gateway-conf"
-        }]
-    }
-}
-EOF
-```
+## Migration steps
+### 1. Install Mender Gateway
+Follow the [Production installation with Kubernetes guide](../03.Production-installation-with-kubernetes/docs.md) to install the Mender Gateway with mTLS support.
+
+!!!!! Make sure to use the same keys and certificates that you used for the `mtls-ambassador` deployment.
+
+### 2. Verify the Load Balancer is deployed
+Depending on your cloud provider, you should have a L4 Load Balancer deployed in front of the Mender Gateway service.
+Take a note of the Load Balancer's IP address or DNS name.
+
+### 3. Update your fleet DNS
+Update your DNS record to point to the new Load Balancer IP address or DNS name of the Mender Gateway service.
+
+### 4. Verification
+Verify that your devices are still able to connect to the Mender server using the new Load Balancer and the Mender Gateway service.
+
+### 5. Cleanup
+You can now cleanup the old `mtls-ambassador` deployment, service, and Load Balancer resources.
+


### PR DESCRIPTION
Using a different migration strategy: if a customer already has a mtls-ambassador setup in place, he could follow this document to replace ti with the mender gateway service, by running a new installation and a DNS switch.

Ticket: MEN-6429

This is based on our previous call with Alan.